### PR TITLE
remove 'assert' as dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
   },
   "homepage": "https://github.com/bholloway/adjust-sourcemap-loader",
   "dependencies": {
-    "assert": "1.4.1",
     "camelcase": "5.0.0",
     "loader-utils": "1.2.3",
     "object-path": "0.11.4",


### PR DESCRIPTION
In node land, it's a builtin module.

The 'assert' npm package is to provide compatibility in browser land.