### PR TITLE
Drop object-path

### DIFF
--- a/codec/utility/get-context-directory.js
+++ b/codec/utility/get-context-directory.js
@@ -1,7 +1,6 @@
 'use strict';
 
-var path       = require('path'),
-    objectPath = require('object-path');
+var path       = require('path');
 
 /**
  * Infer the compilation context directory from options.
@@ -11,7 +10,7 @@ var path       = require('path'),
  */
 function getContextDirectory() {
   /* jshint validthis:true */
-  var context = objectPath.get(this, 'options.context');
+  var context = this.options ? this.options.context : null;
   return !!context && path.resolve(context) || process.cwd();
 }
 

--- a/codec/utility/get-output-directory.js
+++ b/codec/utility/get-output-directory.js
@@ -1,8 +1,7 @@
 'use strict';
 
 var path       = require('path'),
-    fs         = require('fs'),
-    objectPath = require('object-path');
+    fs         = require('fs');
 
 var getContextDirectory = require('./get-context-directory');
 
@@ -14,7 +13,7 @@ var getContextDirectory = require('./get-context-directory');
  */
 function getOutputDirectory() {
   /* jshint validthis:true */
-  var base    = objectPath.get(this, 'options.output.directory'),
+  var base    = this.options && this.options.output ? this.options.output.directory : null,
       absBase = !!base && path.resolve(getContextDirectory.call(this), base),
       isValid = !!absBase && fs.existsSync(absBase) && fs.statSync(absBase).isDirectory();
   return isValid ? absBase : undefined;

--- a/package-lock.json
+++ b/package-lock.json
@@ -237,11 +237,6 @@
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
       "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
     },
-    "object-path": {
-      "version": "0.11.4",
-      "resolved": "https://registry.npmjs.org/object-path/-/object-path-0.11.4.tgz",
-      "integrity": "sha1-NwrnUvvzfePqcKhhwju6iRVpGUk="
-    },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
   "homepage": "https://github.com/bholloway/adjust-sourcemap-loader",
   "dependencies": {
     "loader-utils": "1.2.3",
-    "object-path": "0.11.4",
     "regex-parser": "2.2.10"
   },
   "devDependencies": {


### PR DESCRIPTION
Ref https://github.com/bholloway/adjust-sourcemap-loader/issues/16

A good reason to drop this package since it's not used for any magic and
the fix is pretty straightforward. Later can be simplified with optional
chaining syntax.