### PR TITLE
Fix npm audit issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "adjust-sourcemap-loader",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -230,9 +230,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+      "version": "4.17.20",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
       "dev": true
     },
     "minimatch": {
@@ -245,14 +245,14 @@
       }
     },
     "minimist": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "object-path": {
-      "version": "0.11.4",
-      "resolved": "https://registry.npmjs.org/object-path/-/object-path-0.11.4.tgz",
-      "integrity": "sha1-NwrnUvvzfePqcKhhwju6iRVpGUk="
+      "version": "0.11.5",
+      "resolved": "https://registry.npmjs.org/object-path/-/object-path-0.11.5.tgz",
+      "integrity": "sha512-jgSbThcoR/s+XumvGMTMf81QVBmah+/Q7K7YduKeKVWL7N111unR2d6pZZarSk6kY/caeNxUDyxOvMWyzoU2eg=="
     },
     "once": {
       "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adjust-sourcemap-loader",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Webpack loader that adjusts source maps",
   "main": "index.js",
   "repository": {
@@ -26,7 +26,7 @@
     "assert": "1.4.1",
     "camelcase": "5.0.0",
     "loader-utils": "1.2.3",
-    "object-path": "0.11.4",
+    "object-path": "0.11.5",
     "regex-parser": "2.2.10"
   },
   "devDependencies": {


### PR DESCRIPTION
Currently, there is an issue with `npm audit` and `object-path@0.11.4`. I know that you removed it in version 3.0.0 of this library, but as popular apps like https://github.com/facebook/create-react-app use it in version 2.0.0 you might want to consider this PR (applied to 2.0.0 as 2.0.1) and publish a patch of 2.0.1 on npm.

See https://github.com/facebook/create-react-app/issues/9842 for a related discussion.